### PR TITLE
add media codecs evasion strategy

### DIFF
--- a/pyppeteer_stealth/__init__.py
+++ b/pyppeteer_stealth/__init__.py
@@ -9,6 +9,7 @@ from .navigator_webdriver import navigator_webdriver
 from .user_agent import user_agent
 from .webgl_vendor import webgl_vendor
 from .window_outerdimensions import window_outerdimensions
+from .media_codecs import media_codecs
 
 
 async def stealth(page: Page) -> None:
@@ -24,3 +25,4 @@ async def stealth(page: Page) -> None:
     await user_agent(page)
     await webgl_vendor(page)
     await window_outerdimensions(page)
+    await media_codecs(page)


### PR DESCRIPTION
As per js upstream: https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth/evasions/media.codecs

> Fix Chromium not reporting "probably" to codecs like videoEl.canPlayType('video/mp4; codecs="avc1.42E01E"'). (Chromium doesn't support proprietary codecs, only Chrome does)

tested on http://g2.com; before this strategy 100% distils bot protection detection, with this patch it's not detected.