### PR TITLE
Bring up to date with puppeteer-extra-plugin-stealth

### DIFF
--- a/pyppeteer_stealth/__init__.py
+++ b/pyppeteer_stealth/__init__.py
@@ -4,6 +4,7 @@ from .chrome_app import chrome_app
 from .chrome_runtime import chrome_runtime
 from .iframe_content_window import iframe_content_window
 from .media_codecs import media_codecs
+from .navigator_hardware_concurrency import navigator_hardware_concurrency
 from .navigator_languages import navigator_languages
 from .navigator_permissions import navigator_permissions
 from .navigator_plugins import navigator_plugins
@@ -17,13 +18,14 @@ from .window_outerdimensions import window_outerdimensions
 
 async def stealth(page: Page, **kwargs) -> None:
     if not isinstance(page, Page):
-        raise ValueError("page must is pyppeteer.page.Page")
+        raise ValueError("page must be pyppeteer.page.Page")
 
     await with_utils(page, **kwargs)
     await chrome_app(page, **kwargs)
     await chrome_runtime(page, **kwargs)
     await iframe_content_window(page, **kwargs)
     await media_codecs(page, **kwargs)
+    await navigator_hardware_concurrency(page, **kwargs)
     await navigator_languages(page, **kwargs)
     await navigator_permissions(page, **kwargs)
     await navigator_plugins(page, **kwargs)

--- a/pyppeteer_stealth/__init__.py
+++ b/pyppeteer_stealth/__init__.py
@@ -4,6 +4,7 @@ from .chrome_app import chrome_app
 from .chrome_runtime import chrome_runtime
 from .iframe_content_window import iframe_content_window
 from .media_codecs import media_codecs
+from .sourceurl import sourceurl
 from .navigator_hardware_concurrency import navigator_hardware_concurrency
 from .navigator_languages import navigator_languages
 from .navigator_permissions import navigator_permissions
@@ -25,6 +26,7 @@ async def stealth(page: Page, **kwargs) -> None:
     await chrome_runtime(page, **kwargs)
     await iframe_content_window(page, **kwargs)
     await media_codecs(page, **kwargs)
+    await sourceurl(page, **kwargs)
     await navigator_hardware_concurrency(page, **kwargs)
     await navigator_languages(page, **kwargs)
     await navigator_permissions(page, **kwargs)

--- a/pyppeteer_stealth/js/iframe.contentWindow.js
+++ b/pyppeteer_stealth/js/iframe.contentWindow.js
@@ -69,7 +69,7 @@
     // Adds a hook to intercept iframe creation events
     const addIframeCreationSniffer = () => {
       /* global document */
-      const createElement = {
+      const createElementHandler = {
         // Make toString() native
         get(target, key) {
           return Reflect.get(target, key)
@@ -86,9 +86,10 @@
         }
       }
       // All this just due to iframes with srcdoc bug
-      document.createElement = new Proxy(
-        document.createElement,
-        createElement
+      utils.replaceWithProxy(
+        document,
+        'createElement',
+        createElementHandler
       )
     }
 

--- a/pyppeteer_stealth/js/navigator.hardwareConcurrency.js
+++ b/pyppeteer_stealth/js/navigator.hardwareConcurrency.js
@@ -1,0 +1,12 @@
+// https://github.com/berstend/puppeteer-extra/blob/3ea4ebca4237bb45ce402ba6a44d852e3499cb5f/packages/puppeteer-extra-plugin-stealth/evasions/navigator.hardwareConcurrency/index.js
+
+(hardwareConcurrency) => {
+    const patchNavigator = (name, value) =>
+        utils.replaceProperty(Object.getPrototypeOf(navigator), name, {
+            get() {
+                return value
+            }
+        })
+    patchNavigator('hardwareConcurrency', hardwareConcurrency || 4)
+}
+    

--- a/pyppeteer_stealth/navigator_hardware_concurrency.py
+++ b/pyppeteer_stealth/navigator_hardware_concurrency.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from pyppeteer.page import Page
+
+
+async def navigator_hardware_concurrency(page: Page, hardwareConcurrency: int = 4, **kwargs) -> None:
+    await page.evaluateOnNewDocument(
+        Path(__file__).parent.joinpath("js/navigator.hardwareConcurrency.js").read_text(),
+        hardwareConcurrency,
+    )

--- a/pyppeteer_stealth/sourceurl.py
+++ b/pyppeteer_stealth/sourceurl.py
@@ -1,0 +1,23 @@
+from pyppeteer.page import Page
+
+
+# https://github.com/berstend/puppeteer-extra/blob/9eacda61fc34f7994a0aa253097c473c19c0d1bf/packages/puppeteer-extra-plugin-stealth/evasions/sourceurl/index.js
+async def sourceurl(page: Page, **kwargs) -> None:
+    if (not page or not page._client or not page._client.send):
+        return
+    
+    def new_send(method, params = None):
+        if not method or not params:
+            return page._client.old_send(method, params)
+
+        methodsToPatch = {
+            'Runtime.evaluate': 'expression',
+            'Runtime.callFunctionOn': 'functionDeclaration'
+        }
+        SOURCE_URL_SUFFIX = '//# sourceURL=__pyppeteer_evaluation_script__'
+        if method in methodsToPatch:
+            params[methodsToPatch[method]] = params[methodsToPatch[method]].replace(SOURCE_URL_SUFFIX, '')
+        return page._client.old_send(method, params)
+            
+    page._client.old_send = page._client.send
+    page._client.send = new_send


### PR DESCRIPTION
The first 3 commits are essentially copy/paste from commits to puppeteer-extra-plugin-stealth. For the `sourceurl` evasion I followed the pattern in [this evasion](https://github.com/berstend/puppeteer-extra/blob/9eacda61fc34f7994a0aa253097c473c19c0d1bf/packages/puppeteer-extra-plugin-stealth/evasions/sourceurl/index.js), but had to take some liberties since it was dealing directly with the cdp client.

I also noticed that [this commit](https://github.com/berstend/puppeteer-extra/commit/889d711a3b585f57a5c776708e849225b799b247#diff-a57a7990ea0a3545d46f0f1f2cd3ea770d7aa3e74bb5f3983d27339275e3404e) was merged, but since that would require actually wrapping the browser instantiation, I didn't implement anything for that.