### PR TITLE
Bring up to date with puppeteer-extra-stealth, add ability to disable evasions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ stealth(
   mask_linux: bool = True,
   webgl_vendor: str = "Intel Inc.",
   renderer: str = "Intel Iris OpenGL Engine",
+  disabled_evasions: list = [],
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ stealth(
 )
 ```
 
+List of valid evasion names to pass into `disabled_evasions`:
+```python
+['chrome_app',
+ 'chrome_runtime',
+ 'iframe_content_window',
+ 'media_codecs',
+ 'sourceurl',
+ 'navigator_hardware_concurrency',
+ 'navigator_languages',
+ 'navigator_permissions',
+ 'navigator_plugins',
+ 'navigator_vendor',
+ 'navigator_webdriver',
+ 'user_agent_override',
+ 'webgl_vendor',
+ 'window_outerdimensions']
+```
+
 ## Test results
 
 ### Pyppeteer without stealth

--- a/pyppeteer_stealth/__init__.py
+++ b/pyppeteer_stealth/__init__.py
@@ -47,5 +47,5 @@ async def stealth(page: Page, disabled_evasions: list = [], **kwargs) -> None:
 
     await with_utils(page, **kwargs)
 
-    for evasion_name, evasion in evasion_dict.items():
+    for evasion in evasion_dict.values():
         await evasion(page, **kwargs)

--- a/pyppeteer_stealth/__init__.py
+++ b/pyppeteer_stealth/__init__.py
@@ -12,27 +12,40 @@ from .navigator_plugins import navigator_plugins
 from .navigator_vendor import navigator_vendor
 from .navigator_webdriver import navigator_webdriver
 from .user_agent_override import user_agent_override
-from .utils import with_utils
 from .webgl_vendor import webgl_vendor
 from .window_outerdimensions import window_outerdimensions
+from .utils import with_utils
 
 
-async def stealth(page: Page, **kwargs) -> None:
+async def stealth(page: Page, disabled_evasions: list = [], **kwargs) -> None:
     if not isinstance(page, Page):
         raise ValueError("page must be pyppeteer.page.Page")
+    if not isinstance(disabled_evasions, list):
+        raise ValueError("disabled_evasions must be a list")
+
+    evasion_dict = {
+        "chrome_app": chrome_app,
+        "chrome_runtime": chrome_runtime,
+        "iframe_content_window": iframe_content_window,
+        "media_codecs": media_codecs,
+        "sourceurl": sourceurl,
+        "navigator_hardware_concurrency": navigator_hardware_concurrency,
+        "navigator_languages": navigator_languages,
+        "navigator_permissions": navigator_permissions,
+        "navigator_plugins": navigator_plugins,
+        "navigator_vendor": navigator_vendor,
+        "navigator_webdriver": navigator_webdriver,
+        "user_agent_override": user_agent_override,
+        "webgl_vendor": webgl_vendor,
+        "window_outerdimensions": window_outerdimensions,
+    }
+
+    for evasion in disabled_evasions:
+        if evasion not in evasion_dict:
+            raise ValueError("{} is not a valid evasion name".format(evasion))
+        del evasion_dict[evasion]
 
     await with_utils(page, **kwargs)
-    await chrome_app(page, **kwargs)
-    await chrome_runtime(page, **kwargs)
-    await iframe_content_window(page, **kwargs)
-    await media_codecs(page, **kwargs)
-    await sourceurl(page, **kwargs)
-    await navigator_hardware_concurrency(page, **kwargs)
-    await navigator_languages(page, **kwargs)
-    await navigator_permissions(page, **kwargs)
-    await navigator_plugins(page, **kwargs)
-    await navigator_vendor(page, **kwargs)
-    await navigator_webdriver(page, **kwargs)
-    await user_agent_override(page, **kwargs)
-    await webgl_vendor(page, **kwargs)
-    await window_outerdimensions(page, **kwargs)
+
+    for evasion_name, evasion in evasion_dict.items():
+        await evasion(page, **kwargs)

--- a/pyppeteer_stealth/js/navigator.permissions.js
+++ b/pyppeteer_stealth/js/navigator.permissions.js
@@ -1,23 +1,43 @@
 // https://github.com/berstend/puppeteer-extra/blob/c44c8bb0224c6bba2554017bfb9d7a1d0119f92f/packages/puppeteer-extra-plugin-stealth/evasions/navigator.permissions/index.js
 
 () => {
-  const handler = {
-    apply: function (target, ctx, args) {
-      const param = (args || [])[0]
+  const isSecure = document.location.protocol.startsWith("https");
 
-      if (param && param.name && param.name === 'notifications') {
-        const result = { state: Notification.permission }
-        Object.setPrototypeOf(result, PermissionStatus.prototype)
-        return Promise.resolve(result)
-      }
-
-      return utils.cache.Reflect.apply(...arguments)
-    }
+  // In headful on secure origins the permission should be "default", not "denied"
+  if (isSecure) {
+    utils.replaceGetterWithProxy(Notification, "permission", {
+      apply() {
+        return "default";
+      },
+    });
   }
 
-  utils.replaceWithProxy(
-    window.navigator.permissions.__proto__, // eslint-disable-line no-proto
-    'query',
-    handler
-  )
+  // Another weird behavior:
+  // On insecure origins in headful the state is "denied",
+  // whereas in headless it's "prompt"
+  if (!isSecure) {
+    const handler = {
+      apply(target, ctx, args) {
+        const param = (args || [])[0];
+
+        const isNotifications =
+          param && param.name && param.name === "notifications";
+        if (!isNotifications) {
+          return utils.cache.Reflect.apply(...arguments);
+        }
+
+        return Promise.resolve(
+          Object.setPrototypeOf(
+            {
+              state: "denied",
+              onchange: null,
+            },
+            PermissionStatus.prototype
+          )
+        );
+      },
+    };
+    // Note: Don't use `Object.getPrototypeOf` here
+    utils.replaceWithProxy(Permissions.prototype, "query", handler);
+  }
 }

--- a/pyppeteer_stealth/js/utils.js
+++ b/pyppeteer_stealth/js/utils.js
@@ -42,7 +42,7 @@
           // We try to use a known "anchor" line for that and strip it with everything above it.
           // If the anchor line cannot be found for some reason we fall back to our blacklist approach.
 
-          const stripWithBlacklist = stack => {
+          const stripWithBlacklist = (stack, stripFirstLine = true) => {
             const blacklist = [
               `at Reflect.${trap} `, // e.g. Reflect.get or Reflect.apply
               `at Object.${trap} `, // e.g. Object.get or Object.apply
@@ -52,16 +52,16 @@
               err.stack
                 .split('\n')
                 // Always remove the first (file) line in the stack (guaranteed to be our proxy)
-                .filter((line, index) => index !== 1)
+                .filter((line, index) => !(index === 1 && stripFirstLine))
                 // Check if the line starts with one of our blacklisted strings
                 .filter(line => !blacklist.some(bl => line.trim().startsWith(bl)))
                 .join('\n')
             )
           }
 
-          const stripWithAnchor = stack => {
+          const stripWithAnchor = (stack, anchor) => {
             const stackArr = stack.split('\n')
-            const anchor = `at Object.newHandler.<computed> [as ${trap}] ` // Known first Proxy line in chromium
+            anchor = anchor || `at Object.newHandler.<computed> [as ${trap}] ` // Known first Proxy line in chromium
             const anchorIndex = stackArr.findIndex(line =>
               line.trim().startsWith(anchor)
             )
@@ -72,6 +72,16 @@
             // Note: We're keeping the 1st line (zero index) as it's unrelated (e.g. `TypeError`)
             stackArr.splice(1, anchorIndex)
             return stackArr.join('\n')
+          }
+
+          // Special cases due to our nested toString proxies
+          err.stack = err.stack.replace(
+            'at Object.toString (',
+            'at Function.toString ('
+          )
+          if ((err.stack || '').includes('at Function.toString (')) {
+            err.stack = stripWithBlacklist(err.stack, false)
+            throw err
           }
 
           // Try using the anchor method, fallback to blacklist if necessary


### PR DESCRIPTION
See [this PR](https://github.com/berstend/puppeteer-extra/pull/429) and [this PR](https://github.com/berstend/puppeteer-extra/pull/427) for the evasion updates. I figured it would be nice to have the option to disable certain evasions since puppeteer-extra has this feature. Since we don't actually wrap the browser instantiation like they do, we can't really use the same mechanism. I'm open to changing the pattern I implemented, but I think this will be a good starting point at least.